### PR TITLE
change EXTRA_CFLAGS to ccflags-y

### DIFF
--- a/module/Makefile
+++ b/module/Makefile
@@ -1,5 +1,5 @@
 obj-m := batch.o
-EXTRA_CFLAGS := -I$M/../include -Wno-error
+ccflags-y := -I$M/../include -Wno-error
 ifndef V
   override V = $(shell uname -r)
 endif


### PR DESCRIPTION
https://www.kernel.org/doc/Documentation/kbuild/makefiles.txt

3.7 Compilation flags
    ccflags-y, asflags-y and ldflags-y
	These three flags apply only to the kbuild makefile in which they
	are assigned. They are used for all the normal cc, as and ld
	invocations happening during a recursive build.
	Note: Flags with the same behaviour were previously named:
	EXTRA_CFLAGS, EXTRA_AFLAGS and EXTRA_LDFLAGS.
	They are still supported but their usage is deprecated.

Seems that they are now unsupported (my kernel 6.16.1-arch1-1), which makes https://github.com/c-blake/batch/issues/1 happen again.